### PR TITLE
Displayer fps

### DIFF
--- a/source/media/Displayer.ooc
+++ b/source/media/Displayer.ooc
@@ -9,14 +9,16 @@ import DisplayWriter
 Displayer: class extends DisplayWriter {
 	_process: Process
 	_writer: PipeWriter
-	init: func {
+	_fps: UInt
+	init: func (fps := 25) {
+		_fps = fps
 		super()
 	}
 	write: override func (pointer: Pointer, length: Int) {
 		this _writer write(pointer as CString, length)
 	}
 	start: override func (size: IntVector2D, format: String) {
-		this _process = Process new(["avplay", "-hide_banner", "-loglevel", "panic", "-f", "rawvideo", "-pixel_format", format, "-video_size", size x toString() + "x" + size y toString(), "-i", "-"])
+		this _process = Process new(["avplay", "-hide_banner", "-loglevel", "panic", "-f", "rawvideo", "-pixel_format", format, "-framerate", _fps toString(), "-video_size", size x toString() + "x" + size y toString(), "-i", "-"])
 		this _process stdIn = Pipe new()
 		this _writer = this _process stdIn writer()
 		this _process executeNoWait()

--- a/source/media/Displayer.ooc
+++ b/source/media/Displayer.ooc
@@ -23,4 +23,8 @@ Displayer: class extends DisplayWriter {
 		this _writer = this _process stdIn writer()
 		this _process executeNoWait()
 	}
+	free: override func () {
+		_process kill()
+		super()
+	}
 }


### PR DESCRIPTION
This enables the application to control the playback speed of the output, and it also makes it possible to close the avplay window automatically when the host application terminates.